### PR TITLE
Support for ACME client access on http restricted systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Variables associated with initiating a certificate request and set-up of renewal
 - `cerbot_certname` - defines the internal name certbot will use to reference/track the certificate
 - `certbot_renewhook` - OPTIONAL - defines the command that should run after a successful certificate renewal
 - `certbot_make_cert_request` - defines whether a certificate request should be made (`true`/`false`)
+- `certbot_http_access_restricted` - defines whether the system running certbot will have restricted access to http (`true`/`false`)
 - `certbot_certificate_path` - defines the filesystem path to the requested/issued certificate
 - `certbot_request_command` - defines the command to use to initiate a certbot certificate request
 - `certbot_cron_renew_user` - defines the user the cron job should run as

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,10 @@ acme_accnt_priv_key_json: ""
 # Set if a certificate request should be made (true/false)
 certbot_make_cert_request: "false"
 
+# Set if the system running certbot will have restricted access to http
+# i.e. port 80 will not be world accessible
+certbot_http_access_restricted: "false"
+
 # List of domain names to associate with the certificate
 certbot_domains: []
 #  - example1.library.ucla.edu
@@ -62,4 +66,4 @@ certbot_cron_renew_hour: "0,12"
 certbot_cron_renew_minute: "5"
 certbot_cron_renew_command: >-
   python -c 'import random; import time; time.sleep(random.random() * 3600)'
-  && certbot renew --quiet
+  && /usr/local/bin/certbot_renew

--- a/tasks/request_certificate.yml
+++ b/tasks/request_certificate.yml
@@ -12,6 +12,8 @@
         grep -w http |
         grep "0.0.0.0"
       register: firewall_http_access
+      ignore_errors: true
+      changed_when: false
 
     - name: Open port 80 to allow certificate authentication checks
       firewalld:

--- a/tasks/request_certificate.yml
+++ b/tasks/request_certificate.yml
@@ -5,6 +5,32 @@
     path: "{{ certbot_certificate_path }}"
   register: cert_status
 
-- name: Initiate certificate request
-  command: "{{ certbot_request_command }}"
+- block:
+    - name: Determine if port 80 is open to the world
+      shell: >
+        firewall-cmd --list-all |
+        grep -w http |
+        grep "0.0.0.0"
+      register: firewall_http_access
+
+    - name: Open port 80 to allow certificate authentication checks
+      firewalld:
+        zone: "public"
+        service: "http"
+        source: "0.0.0.0"
+        permanent: "no"
+        state: "enabled"
+      when: firewall_http_access.rc != 0
+
+    - name: Initiate certificate request
+      command: "{{ certbot_request_command }}"
+
+    - name: Close port 80 access
+      firewalld:
+        zone: "public"
+        service: "http"
+        source: "0.0.0.0"
+        permanent: "no"
+        state: "absent"
+      when: firewall_http_access.rc != 0
   when: not cert_status.stat.exists | bool

--- a/tasks/setup_renew_cron.yml
+++ b/tasks/setup_renew_cron.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Put in place certbot renewal cron job script
+  template:
+    src: "certbot_renew.j2"
+    dest: "/usr/local/bin/certbot_renew"
+    owner: "root"
+    group: "root"
+    mode: "0750"
+
 - name: Create cron job for certificate renewal
   cron:
     name: "Certbot certificate renewal"

--- a/templates/certbot_renew.j2
+++ b/templates/certbot_renew.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+###
+#
+# THIS IS AN ANSIBLE MANAGED SCRIPT - DO NOT EDIT
+#
+###
+
+# This script is meant to be run as part of a cron job to renew this systems
+# certificates requested/issued via certbot
+
+{% if certbot_http_access_restricted | bool %}
+firewall-cmd --zone=public --add-port=80/tcp
+firewall-cmd --reload
+
+certbot renew --quiet
+
+firewall-cmd --zone=public --remove-port=80/tcp
+firewall-cmd --reload
+{% else %}
+certbot renew --quiet
+{% endif %}

--- a/templates/certbot_renew.j2
+++ b/templates/certbot_renew.j2
@@ -9,6 +9,12 @@
 # This script is meant to be run as part of a cron job to renew this systems
 # certificates requested/issued via certbot
 
+web_srv_proc=$(lsof -i:80 | tail -1 | awk '{ print $1 }')
+
+if [ ! -z "${web_srv_proc}" ] ; then
+  systemctl stop ${web_srv_proc}
+fi
+
 {% if certbot_http_access_restricted | bool %}
 firewall-cmd --zone=public --add-port=80/tcp
 firewall-cmd --reload
@@ -20,3 +26,7 @@ firewall-cmd --reload
 {% else %}
 certbot renew --quiet
 {% endif %}
+
+if [ ! -z "${web_srv_proc}" ] ; then
+  systemctl start ${web_srv_proc}
+fi


### PR DESCRIPTION
There may be hosts where access through the local host firewall via port 80 is restricted - this could be common on dev, test, and stage systems. 

This PR includes functionality to ensure firewall access is open on port 80 for the initial certificate request.

In addition, since the certificate request process in this role uses the **standalone** authenticator, it is necessary to ensure no other process is bound to port 80 when during certificate renewal. 

This PR includes functionality to ensure firewall access is open on port 80 during certificate renewal and that any process bound to port 80 is stopped. After renewal is complete, the process bound to port 80 will restart. 