### PR TITLE
Remove command to reload firewall after add/remove port 80 access

### DIFF
--- a/templates/certbot_renew.j2
+++ b/templates/certbot_renew.j2
@@ -17,12 +17,10 @@ fi
 
 {% if certbot_http_access_restricted | bool %}
 firewall-cmd --zone=public --add-port=80/tcp
-firewall-cmd --reload
 
 certbot renew --quiet
 
 firewall-cmd --zone=public --remove-port=80/tcp
-firewall-cmd --reload
 {% else %}
 certbot renew --quiet
 {% endif %}


### PR DESCRIPTION
I discovered there is no need to reload the firewall after adding/removing port 80 access. In fact, since I'm stating these are non-permanent changes, they take affect immediately. Reloading the firewall forces a read of the zone config, wiping-out the temporary changes. 