### PR TITLE
Put renewhook variable logic into one set of brackets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,7 @@ certbot_request_command: >-
   certbot certonly --standalone
   --domain {{ certbot_domains | join(',') }}
   --cert-name {{ cerbot_certname }}
-  {{ '--renew-hook ' if certbot_renewhook != '' else '' }}{{ certbot_renewhook | quote }}
+  {{ '--renew-hook ' + certbot_renewhook|quote if certbot_renewhook != '' else '' }}
 
 # Certbot cron set-up parameters
 certbot_cron_renew_user: "root"


### PR DESCRIPTION
When we get to the task of making the certificate request, the certbot command that initiates the request is reporting a syntax error. I believe this caused when I'm not defining the renew hook variable with a value. When this happens, it looks like the command is being appended with a set of quotes, causing this error.

I think putting all of the logic into one set of {{ }} will fix this. 