### PR TITLE
Define PATH variable to run common system commands

### DIFF
--- a/templates/certbot_renew.j2
+++ b/templates/certbot_renew.j2
@@ -9,6 +9,8 @@
 # This script is meant to be run as part of a cron job to renew this systems
 # certificates requested/issued via certbot
 
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
 web_srv_proc=$(lsof -i:80 | tail -1 | awk '{ print $1 }')
 
 if [ ! -z "${web_srv_proc}" ] ; then


### PR DESCRIPTION
Explicitly defining the `PATH` within the script to ensure the necessary system-level commands are able to run without specifying the full path. 