### PR TITLE
Modify certbot renew to use pre-hook and post-hook parameters

### DIFF
--- a/templates/certbot_renew.j2
+++ b/templates/certbot_renew.j2
@@ -13,20 +13,18 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
 web_srv_proc=$(lsof -i:80 | tail -1 | awk '{ print $1 }')
 
-if [ ! -z "${web_srv_proc}" ] ; then
-  systemctl stop ${web_srv_proc}
-fi
-
 {% if certbot_http_access_restricted | bool %}
 firewall-cmd -q --zone=public --add-port=80/tcp
-
-certbot renew --quiet
-
+if [ ! -z "${web_srv_proc}" ] ; then
+  certbot renew --quiet --pre-hook "systemctl stop ${web_srv_proc}" --post-hook "systemctl start ${web_srv_proc}"
+else
+  certbot renew --quiet
+fi
 firewall-cmd -q --zone=public --remove-port=80/tcp
 {% else %}
-certbot renew --quiet
-{% endif %}
-
 if [ ! -z "${web_srv_proc}" ] ; then
-  systemctl start ${web_srv_proc}
+  certbot renew --quiet --pre-hook "systemctl stop ${web_srv_proc}" --post-hook "systemctl start ${web_srv_proc}"
+else
+  certbot renew --quiet
 fi
+{% endif %}


### PR DESCRIPTION
If there is an existing web server bound to port 80, the previous version of this script would force it to stop every time the renewal scripts runs. This would cause two small web server outtages twice a day.

By switching to the built-in certbot pre-hook and post-hook parameters, the web server will only be stopped/started if the certificate is within the renewal period. 