### PR TITLE
Change cron_renew_hour to be only midnight

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ certbot_request_command: >-
 
 # Certbot cron set-up parameters
 certbot_cron_renew_user: "root"
-certbot_cron_renew_hour: "0,12"
+certbot_cron_renew_hour: "0"
 certbot_cron_renew_minute: "5"
 certbot_cron_renew_command: >-
   python -c 'import random; import time; time.sleep(random.random() * 3600)'


### PR DESCRIPTION
Instead of certbot_renew cron running at 00:05 and 12:05, changing to only run at 00:05 since when a certificate needs to be renewed, it is possible an existing web server bound to port 80 will need to be stopped. Don't want any disruption during usual business hours. 