### PR TITLE
Change lookup to query to return list type to loop

### DIFF
--- a/tasks/request_certificate.yml
+++ b/tasks/request_certificate.yml
@@ -2,4 +2,4 @@
 
 - name: Loop through certificate requests
   include_tasks: cert_req_loop.yml
-  loop: "{{ lookup('dict', certbot_certificates) }}"
+  loop: "{{ query('dict', certbot_certificates) }}"


### PR DESCRIPTION
`lookup` returns a string type to the loop
`query` returns a list type to the loop

Reference: https://docs.ansible.com/ansible/latest/plugins/lookup.html#invoking-lookup-plugins-with-query