### PR TITLE
Adjust logic of haproxy auto renewal cron script

### DIFF
--- a/templates/certbot_renew_haproxy.j2
+++ b/templates/certbot_renew_haproxy.j2
@@ -16,9 +16,9 @@ CERTNAMES=$(find ${CERTBASEPATH} -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 CERT_EXP_LIMIT=30
 
 for NAME in ${CERTNAMES} ; do
-  VALID_DAYS=$( (certbot certificates --cert-name "${NAME}" | grep -o "VALID: [0-9]* days" | awk '{ print $2 }') 2> /dev/null )
+  VALID_DAYS=$( (certbot certificates --cert-name "${NAME}" 2> /dev/null | grep -o "VALID: [0-9]* days" | awk '{ print $2 }') )
 
-  if [ "${VALID_DAYS}" -le "${CERT_EXP_LIMIT}" ] ; then
+  if [ "${VALID_DAYS}" -lt "${CERT_EXP_LIMIT}" ] ; then
     certbot renew --quiet --cert-name "${NAME}" --http-01-port {{ certbot_http_challenge_port }}
 
     # Package certificate in haproxy pem file format


### PR DESCRIPTION
Adjusted the following items:
* On line 19 - Move sending stderr to /dev/null earlier in the statement
* On line 21 - change if statement to use less than instead of less than or equal since renewal only occurs if cert will expire in less than 30 days. 